### PR TITLE
perf: replace Postgres FOR UPDATE with Redis atomic counters for stock

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,49 @@
 services:
-  redis:
+  redis-order:
     image: redis:alpine
-    container_name: redis
+    container_name: redis-order
     ports:
-      - "6379:6379"
+      - "6380:6379"
     stop_grace_period: 5s
+    networks:
+      - app
+
+  redis-payment:
+    image: redis:alpine
+    container_name: redis-payment
+    ports:
+      - "6381:6379"
+    stop_grace_period: 5s
+    networks:
+      - app
+
+  redis-stock:
+    image: redis:alpine
+    container_name: redis-stock
+    ports:
+      - "6382:6379"
+    stop_grace_period: 5s
+    networks:
+      - app
+
+  postgres-stock:
+    image: postgres:16-alpine
+    container_name: postgres-stock
+    ports:
+      - "5432:5432"
+    stop_grace_period: 5s
+    command: ["postgres", "-c", "max_connections=500"]
+    environment:
+      - POSTGRES_DB=stock
+      - POSTGRES_USER=stock
+      - POSTGRES_PASSWORD=stock
+    volumes:
+      - ./stock/db/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U stock -d stock"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
     networks:
       - app
 
@@ -124,9 +163,18 @@ services:
     environment:
       - LOKI_URL=http://loki:3100
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://tempo:4318
+      - STOCK_INITIAL_QUANTITY=1000000000
+      - POSTGRES_URL=postgres://stock:stock@postgres-stock:5432/stock?sslmode=disable
+      - REDIS_ADDR=redis-stock:6379
     depends_on:
-      - loki
-      - tempo
+      loki:
+        condition: service_started
+      tempo:
+        condition: service_started
+      postgres-stock:
+        condition: service_healthy
+      redis-stock:
+        condition: service_started
     networks:
       - app
   payment:
@@ -150,13 +198,13 @@ services:
       - "3131:3131"
     stop_grace_period: 10s
     environment:
-      - REDIS_ADDR=redis:6379
+      - REDIS_ADDR=redis-order:6379
       - STOCK_BASE_URL=http://stock:3133
       - PAYMENT_BASE_URL=http://payment:3132
       - LOKI_URL=http://loki:3100
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://tempo:4318
     depends_on:
-      - redis
+      - redis-order
       - stock
       - payment
       - loki

--- a/stock/cmd/api/http_server.go
+++ b/stock/cmd/api/http_server.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"io"
@@ -9,12 +10,15 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	_ "github.com/lib/pq"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/giovaniif/e-commerce/stock/domain/item"
+	"github.com/redis/go-redis/v9"
+	"github.com/giovaniif/e-commerce/stock/infra/gateways"
 	"github.com/giovaniif/e-commerce/stock/infra/loki"
 	"github.com/giovaniif/e-commerce/stock/infra/metrics"
 	"github.com/giovaniif/e-commerce/stock/infra/repositories"
@@ -40,10 +44,51 @@ type CompleteRequest struct {
 }
 
 func StartServer() {
-	items := make(map[int32]*item.Item)
-	items[1] = &item.Item{Id: 1, Price: 10, InitialStock: 10}
-	reservations := make(map[int32]*item.Reservation)
-	itemRepository := repositories.NewItemRepository(items, reservations)
+	initialStock := int32(10)
+	if s := os.Getenv("STOCK_INITIAL_QUANTITY"); s != "" {
+		if n, err := strconv.ParseInt(s, 10, 32); err == nil && n > 0 {
+			initialStock = int32(n)
+		}
+	}
+	_ = initialStock // initial stock is seeded via init.sql
+
+	postgresURL := os.Getenv("POSTGRES_URL")
+	if postgresURL == "" {
+		fmt.Println("POSTGRES_URL is required")
+		os.Exit(1)
+	}
+	db, err := sql.Open("postgres", postgresURL)
+	if err != nil {
+		fmt.Printf("Failed to open postgres: %v\n", err)
+		os.Exit(1)
+	}
+	defer db.Close()
+	db.SetMaxOpenConns(80)
+	db.SetMaxIdleConns(40)
+	db.SetConnMaxLifetime(5 * time.Minute)
+	if err := db.Ping(); err != nil {
+		fmt.Printf("Failed to ping postgres: %v\n", err)
+		os.Exit(1)
+	}
+	redisAddr := os.Getenv("REDIS_ADDR")
+	if redisAddr == "" {
+		fmt.Println("REDIS_ADDR is required")
+		os.Exit(1)
+	}
+	rdb := redis.NewClient(&redis.Options{Addr: redisAddr})
+	if err := rdb.Ping(context.Background()).Err(); err != nil {
+		fmt.Printf("Failed to ping Redis (%s): %v\n", redisAddr, err)
+		os.Exit(1)
+	}
+
+	itemRepository := repositories.NewItemRepositoryPostgres(db, rdb)
+	if err := itemRepository.SeedStockCounters(context.Background()); err != nil {
+		fmt.Printf("Failed to seed stock counters: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("Stock counters seeded in Redis")
+
+	idempotencyGateway := gateways.NewIdempotencyGatewayRedis(rdb)
 	reserveUseCase := reserve.NewReserve(itemRepository)
 	releaseUseCase := release.NewRelease(itemRepository)
 	completeUseCase := complete.NewComplete(itemRepository)
@@ -57,7 +102,7 @@ func StartServer() {
 		}
 	}
 	slog.SetDefault(slog.New(slog.NewJSONHandler(logOut, &slog.HandlerOptions{Level: slog.LevelInfo})))
-	slog.Info("stock service started", "port", 3133)
+	slog.Info("stock service started", "port", 3133, "initial_stock_item_1", initialStock)
 
 	shutdownTracing := tracing.Init("stock")
 	if shutdownTracing != nil {
@@ -91,17 +136,31 @@ func StartServer() {
 			c.String(http.StatusBadRequest, err.Error())
 			return
 		}
+		ctx := c.Request.Context()
+		requestID := requestid.FromContext(ctx)
+		if idempotencyGateway != nil && requestID != "" {
+			if resId, fee, found, err := idempotencyGateway.ReserveIdempotency(ctx, requestID); err == nil && found {
+				c.JSON(http.StatusOK, gin.H{"reservationId": resId, "totalFee": fee})
+				return
+			}
+		}
 		reservation, err := reserveUseCase.Reserve(reserveRequest.ItemId, reserveRequest.Quantity)
 		if err != nil {
 			switch {
 			case errors.Is(err, repositories.ErrItemNotFound):
+				slog.ErrorContext(ctx, "reserve failed: item not found", "request_id", requestID, "item_id", reserveRequest.ItemId, "quantity", reserveRequest.Quantity, "error", err)
 				c.String(http.StatusNotFound, err.Error())
 			case errors.Is(err, repositories.ErrInsufficientStock):
+				slog.WarnContext(ctx, "reserve failed: insufficient stock", "request_id", requestID, "item_id", reserveRequest.ItemId, "quantity", reserveRequest.Quantity)
 				c.String(http.StatusConflict, err.Error())
 			default:
+				slog.ErrorContext(ctx, "reserve failed", "request_id", requestID, "item_id", reserveRequest.ItemId, "quantity", reserveRequest.Quantity, "error", err)
 				c.String(http.StatusInternalServerError, err.Error())
 			}
 			return
+		}
+		if idempotencyGateway != nil && requestID != "" {
+			_ = idempotencyGateway.SaveReserveResult(ctx, requestID, reservation.ReservationId, reservation.TotalFee)
 		}
 		c.JSON(http.StatusOK, gin.H{"reservationId": reservation.ReservationId, "totalFee": reservation.TotalFee})
 	})
@@ -112,29 +171,48 @@ func StartServer() {
 			c.String(http.StatusBadRequest, err.Error())
 			return
 		}
+		ctx := c.Request.Context()
+		if idempotencyGateway != nil {
+			if found, err := idempotencyGateway.ReleaseIdempotency(ctx, releaseRequest.ReservationId); err == nil && found {
+				c.String(http.StatusOK, "Release successful")
+				return
+			}
+		}
 		err := releaseUseCase.Release(release.Input{ReservationId: releaseRequest.ReservationId})
 		if err != nil {
+			slog.ErrorContext(ctx, "release failed", "request_id", requestid.FromContext(ctx), "reservation_id", releaseRequest.ReservationId, "error", err)
 			c.String(http.StatusInternalServerError, err.Error())
-		} else {
-			c.String(http.StatusOK, "Release successful")
+			return
 		}
+		if idempotencyGateway != nil {
+			_ = idempotencyGateway.SaveReleaseResult(ctx, releaseRequest.ReservationId)
+		}
+		c.String(http.StatusOK, "Release successful")
 	})
 
 	r.POST("/complete", func(c *gin.Context) {
 		var completeRequest CompleteRequest
 		if err := c.ShouldBindJSON(&completeRequest); err != nil {
-			fmt.Println("failed to bind json")
 			c.String(http.StatusBadRequest, err.Error())
 			return
 		}
+		ctx := c.Request.Context()
+		if idempotencyGateway != nil {
+			if found, err := idempotencyGateway.CompleteIdempotency(ctx, completeRequest.ReservationId); err == nil && found {
+				c.String(http.StatusOK, "Complete successful")
+				return
+			}
+		}
 		err := completeUseCase.Complete(complete.Input{ReservationId: completeRequest.ReservationId})
 		if err != nil {
-			fmt.Println("failed to complete stock")
+			slog.ErrorContext(ctx, "complete failed", "request_id", requestid.FromContext(ctx), "reservation_id", completeRequest.ReservationId, "error", err)
 			c.String(http.StatusInternalServerError, err.Error())
-		} else {
-			fmt.Println("complete successful")
-			c.String(http.StatusOK, "Complete successful")
+			return
 		}
+		if idempotencyGateway != nil {
+			_ = idempotencyGateway.SaveCompleteResult(ctx, completeRequest.ReservationId)
+		}
+		c.String(http.StatusOK, "Complete successful")
 	})
 
 	srv := &http.Server{Addr: ":3133", Handler: r}

--- a/stock/db/init.sql
+++ b/stock/db/init.sql
@@ -1,0 +1,32 @@
+CREATE TABLE IF NOT EXISTS items (
+    id INT PRIMARY KEY,
+    price DECIMAL(10,2) NOT NULL,
+    initial_stock BIGINT NOT NULL
+);
+
+CREATE SEQUENCE IF NOT EXISTS reservation_id_seq;
+
+CREATE TABLE IF NOT EXISTS stock_events (
+    id BIGSERIAL PRIMARY KEY,
+    reservation_id BIGINT NOT NULL,
+    item_id INT NOT NULL REFERENCES items(id),
+    event_type VARCHAR(20) NOT NULL CHECK (event_type IN ('reserved', 'released', 'completed')),
+    quantity INT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_stock_events_item_id ON stock_events(item_id);
+CREATE INDEX IF NOT EXISTS idx_stock_events_reservation_id ON stock_events(reservation_id);
+
+INSERT INTO items (id, price, initial_stock) VALUES
+    (1,  10.00, 1000000000),
+    (2,  25.00, 1000000000),
+    (3,  49.99, 1000000000),
+    (4,   5.00, 1000000000),
+    (5,  99.99, 1000000000),
+    (6,  15.00, 1000000000),
+    (7,  30.00, 1000000000),
+    (8,  75.00, 1000000000),
+    (9,   8.50, 1000000000),
+    (10, 19.99, 1000000000)
+ON CONFLICT DO NOTHING;

--- a/stock/go.mod
+++ b/stock/go.mod
@@ -4,11 +4,12 @@ go 1.25.1
 
 require (
 	github.com/gin-gonic/gin v1.10.1
+	github.com/lib/pq v1.11.2
 	github.com/prometheus/client_golang v1.23.2
+	github.com/redis/go-redis/v9 v9.18.0
 	go.opentelemetry.io/otel v1.40.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.40.0
 	go.opentelemetry.io/otel/sdk v1.40.0
-	go.opentelemetry.io/otel/trace v1.40.0
 )
 
 require (
@@ -19,6 +20,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.4 // indirect
 	github.com/cloudwego/iasm v0.2.0 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
@@ -45,7 +47,9 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.40.0 // indirect
 	go.opentelemetry.io/otel/metric v1.40.0 // indirect
+	go.opentelemetry.io/otel/trace v1.40.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
+	go.uber.org/atomic v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/arch v0.8.0 // indirect
 	golang.org/x/crypto v0.47.0 // indirect

--- a/stock/go.sum
+++ b/stock/go.sum
@@ -1,5 +1,9 @@
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
+github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
+github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
+github.com/bsm/gomega v1.27.10/go.mod h1:JyEr/xRbxbtgWNi8tIEVPUYZ5Dzef52k01W3YH0H+O0=
 github.com/bytedance/sonic v1.11.6 h1:oUp34TzMlL+OY1OUWxHqsdkgC/Zfc85zGqw9siXjrc0=
 github.com/bytedance/sonic v1.11.6/go.mod h1:LysEHSvpvDySVdC2f87zGWf6CIKJcAvqab1ZaiQtds4=
 github.com/bytedance/sonic/loader v0.1.1 h1:c+e5Pt1k/cy5wMveRDyk2X4B9hF4g7an8N3zCYjJFNM=
@@ -15,6 +19,8 @@ github.com/cloudwego/iasm v0.2.0/go.mod h1:8rXZaNYT2n95jn+zTI1sDr+IgcD2GVs0nlbbQ
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uqxgUFjbI0=
 github.com/gabriel-vasile/mimetype v1.4.3/go.mod h1:d8uq/6HKRL6CGdk+aubisF/M5GcPfT7nKyLpA0lbSSk=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=
@@ -61,6 +67,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
+github.com/lib/pq v1.11.2 h1:x6gxUeu39V0BHZiugWe8LXZYZ+Utk7hSJGThs8sdzfs=
+github.com/lib/pq v1.11.2/go.mod h1:/p+8NSbOcwzAEI7wiMXFlgydTwcgTr3OSKMsD2BitpA=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -82,6 +90,8 @@ github.com/prometheus/common v0.66.1 h1:h5E0h5/Y8niHc5DlaLlWLArTQI7tMrsfQjHV+d9Z
 github.com/prometheus/common v0.66.1/go.mod h1:gcaUsgf3KfRSwHY4dIMXLPV0K/Wg1oZ8+SbZk/HH/dA=
 github.com/prometheus/procfs v0.16.1 h1:hZ15bTNuirocR6u0JZ6BAHHmwS1p8B4P6MRqxtzMyRg=
 github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlTmWl8x/U+Is=
+github.com/redis/go-redis/v9 v9.18.0 h1:pMkxYPkEbMPwRdenAzUNyFNrDgHx9U+DrBabWNfSRQs=
+github.com/redis/go-redis/v9 v9.18.0/go.mod h1:k3ufPphLU5YXwNTUcCRXGxUoF1fqxnhFQmscfkCoDA0=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -101,6 +111,8 @@ github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65EE=
 github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
+github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=
+github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/otel v1.40.0 h1:oA5YeOcpRTXq6NN7frwmwFR0Cn3RhTVZvXsP4duvCms=
@@ -119,6 +131,8 @@ go.opentelemetry.io/otel/trace v1.40.0 h1:WA4etStDttCSYuhwvEa8OP8I5EWu24lkOzp+ZY
 go.opentelemetry.io/otel/trace v1.40.0/go.mod h1:zeAhriXecNGP/s2SEG3+Y8X9ujcJOTqQ5RgdEJcawiA=
 go.opentelemetry.io/proto/otlp v1.9.0 h1:l706jCMITVouPOqEnii2fIAuO3IVGBRPV5ICjceRb/A=
 go.opentelemetry.io/proto/otlp v1.9.0/go.mod h1:xE+Cx5E/eEHw+ISFkwPLwCZefwVjY+pqKg1qcK03+/4=
+go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
+go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.yaml.in/yaml/v2 v2.4.2 h1:DzmwEr2rDGHl7lsFgAHxmNz/1NlQ7xLIrlN2h5d1eGI=

--- a/stock/infra/gateways/idempotency_redis.go
+++ b/stock/infra/gateways/idempotency_redis.go
@@ -1,0 +1,86 @@
+package gateways
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const idempotencyTTL = 24 * time.Hour
+
+type reserveResult struct {
+	ReservationId int32   `json:"reservation_id"`
+	TotalFee      float64 `json:"total_fee"`
+}
+
+type IdempotencyGatewayRedis struct {
+	client *redis.Client
+}
+
+func NewIdempotencyGatewayRedis(client *redis.Client) *IdempotencyGatewayRedis {
+	return &IdempotencyGatewayRedis{client: client}
+}
+
+// ReserveIdempotency checks if a reserve request with this requestId was already processed.
+// Returns (reservationId, totalFee, true, nil) if a cached result exists.
+// Returns (0, 0, false, nil) if this is a new request.
+func (g *IdempotencyGatewayRedis) ReserveIdempotency(ctx context.Context, requestId string) (int32, float64, bool, error) {
+	key := fmt.Sprintf("stock:reserve:%s", requestId)
+	data, err := g.client.Get(ctx, key).Bytes()
+	if err == redis.Nil {
+		return 0, 0, false, nil
+	}
+	if err != nil {
+		return 0, 0, false, fmt.Errorf("redis get: %w", err)
+	}
+	var result reserveResult
+	if err := json.Unmarshal(data, &result); err != nil {
+		return 0, 0, false, fmt.Errorf("unmarshal: %w", err)
+	}
+	return result.ReservationId, result.TotalFee, true, nil
+}
+
+// SaveReserveResult caches the result of a successful reserve call.
+func (g *IdempotencyGatewayRedis) SaveReserveResult(ctx context.Context, requestId string, reservationId int32, totalFee float64) error {
+	key := fmt.Sprintf("stock:reserve:%s", requestId)
+	raw, err := json.Marshal(reserveResult{ReservationId: reservationId, TotalFee: totalFee})
+	if err != nil {
+		return err
+	}
+	return g.client.Set(ctx, key, raw, idempotencyTTL).Err()
+}
+
+// ReleaseIdempotency returns true if this reservationId was already released.
+func (g *IdempotencyGatewayRedis) ReleaseIdempotency(ctx context.Context, reservationId int32) (bool, error) {
+	key := fmt.Sprintf("stock:release:%d", reservationId)
+	exists, err := g.client.Exists(ctx, key).Result()
+	if err != nil {
+		return false, fmt.Errorf("redis exists: %w", err)
+	}
+	return exists > 0, nil
+}
+
+// SaveReleaseResult marks a reservationId as released.
+func (g *IdempotencyGatewayRedis) SaveReleaseResult(ctx context.Context, reservationId int32) error {
+	key := fmt.Sprintf("stock:release:%d", reservationId)
+	return g.client.Set(ctx, key, "1", idempotencyTTL).Err()
+}
+
+// CompleteIdempotency returns true if this reservationId was already completed.
+func (g *IdempotencyGatewayRedis) CompleteIdempotency(ctx context.Context, reservationId int32) (bool, error) {
+	key := fmt.Sprintf("stock:complete:%d", reservationId)
+	exists, err := g.client.Exists(ctx, key).Result()
+	if err != nil {
+		return false, fmt.Errorf("redis exists: %w", err)
+	}
+	return exists > 0, nil
+}
+
+// SaveCompleteResult marks a reservationId as completed.
+func (g *IdempotencyGatewayRedis) SaveCompleteResult(ctx context.Context, reservationId int32) error {
+	key := fmt.Sprintf("stock:complete:%d", reservationId)
+	return g.client.Set(ctx, key, "1", idempotencyTTL).Err()
+}

--- a/stock/infra/repositories/item.go
+++ b/stock/infra/repositories/item.go
@@ -3,6 +3,7 @@ package repositories
 import (
 	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/giovaniif/e-commerce/stock/domain/item"
 )
@@ -13,7 +14,8 @@ var (
 )
 
 type ItemRepository struct {
-	items map[int32]*item.Item
+	mu           sync.RWMutex
+	items        map[int32]*item.Item
 	reservations map[int32]*item.Reservation
 }
 
@@ -22,6 +24,8 @@ func NewItemRepository(items map[int32]*item.Item, reservations map[int32]*item.
 }
 
 func (r *ItemRepository) GetItem(itemId int32) (*item.Item, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	repositoryItem, ok := r.items[itemId]
 	if !ok {
 		return nil, ErrItemNotFound
@@ -37,6 +41,8 @@ func (r *ItemRepository) GetItem(itemId int32) (*item.Item, error) {
 }
 
 func (r *ItemRepository) Reserve(reservationItem *item.Item, quantity int32) (*item.Reservation, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	if reservationItem.GetAvailableStock() < quantity {
 		return nil, ErrInsufficientStock
 	}
@@ -53,7 +59,9 @@ func (r *ItemRepository) Reserve(reservationItem *item.Item, quantity int32) (*i
 	return reservation, nil
 }
 
-func (r *ItemRepository) ReleaseReservation(reservationId int32) (error) {
+func (r *ItemRepository) ReleaseReservation(reservationId int32) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	reservation, ok := r.reservations[reservationId]
 	if !ok {
 		return errors.New("reservation not found")
@@ -65,10 +73,12 @@ func (r *ItemRepository) ReleaseReservation(reservationId int32) (error) {
 		ItemId: reservation.ItemId,
 		Status: "canceled",
 	}
-  return nil
+	return nil
 }
 
 func (r *ItemRepository) CompleteReservation(reservationId int32) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	reservation, ok := r.reservations[reservationId]
 	if !ok {
 		fmt.Printf("reservation %d not found", reservationId)
@@ -85,5 +95,7 @@ func (r *ItemRepository) CompleteReservation(reservationId int32) error {
 }
 
 func (r *ItemRepository) Save(it *item.Item) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	r.items[it.Id] = it
 }

--- a/stock/infra/repositories/item_postgres.go
+++ b/stock/infra/repositories/item_postgres.go
@@ -1,0 +1,158 @@
+package repositories
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/redis/go-redis/v9"
+	_ "github.com/lib/pq"
+	"github.com/giovaniif/e-commerce/stock/domain/item"
+)
+
+type ItemRepositoryPostgres struct {
+	db  *sql.DB
+	rdb *redis.Client
+}
+
+func NewItemRepositoryPostgres(db *sql.DB, rdb *redis.Client) *ItemRepositoryPostgres {
+	return &ItemRepositoryPostgres{db: db, rdb: rdb}
+}
+
+// SeedStockCounters initialises Redis counters and price cache from the items table.
+// Called once at startup so the atomic DECRBY path has a baseline and GetItem never hits Postgres.
+func (r *ItemRepositoryPostgres) SeedStockCounters(ctx context.Context) error {
+	rows, err := r.db.QueryContext(ctx, `SELECT id, price, initial_stock FROM items`)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id int32
+		var price float64
+		var initialStock int64
+		if err := rows.Scan(&id, &price, &initialStock); err != nil {
+			return err
+		}
+		stockKey := fmt.Sprintf("stock:item:%d", id)
+		if err := r.rdb.Set(ctx, stockKey, initialStock, 0).Err(); err != nil {
+			return fmt.Errorf("seed item %d stock: %w", id, err)
+		}
+		priceKey := fmt.Sprintf("stock:item:price:%d", id)
+		if err := r.rdb.Set(ctx, priceKey, price, 0).Err(); err != nil {
+			return fmt.Errorf("seed item %d price: %w", id, err)
+		}
+	}
+	return nil
+}
+
+func (r *ItemRepositoryPostgres) GetItem(itemId int32) (*item.Item, error) {
+	ctx := context.Background()
+	priceKey := fmt.Sprintf("stock:item:price:%d", itemId)
+	priceStr, err := r.rdb.Get(ctx, priceKey).Result()
+	if err == nil {
+		var price float64
+		if _, scanErr := fmt.Sscanf(priceStr, "%f", &price); scanErr == nil {
+			return &item.Item{Id: itemId, Price: price}, nil
+		}
+	}
+	// Fallback to Postgres if cache miss (e.g. unknown item).
+	row := r.db.QueryRow(`SELECT id, price, initial_stock FROM items WHERE id = $1`, itemId)
+	var it item.Item
+	if err := row.Scan(&it.Id, &it.Price, &it.InitialStock); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrItemNotFound
+		}
+		return nil, fmt.Errorf("get item: %w", err)
+	}
+	return &it, nil
+}
+
+func (r *ItemRepositoryPostgres) Reserve(reservationItem *item.Item, quantity int32) (*item.Reservation, error) {
+	ctx := context.Background()
+	key := fmt.Sprintf("stock:item:%d", reservationItem.Id)
+
+	// Atomically decrement — no row lock, no queue, sub-millisecond.
+	remaining, err := r.rdb.DecrBy(ctx, key, int64(quantity)).Result()
+	if err != nil {
+		return nil, fmt.Errorf("redis decr stock: %w", err)
+	}
+	if remaining < 0 {
+		// Not enough stock — compensate and reject.
+		r.rdb.IncrBy(ctx, key, int64(quantity))
+		return nil, ErrInsufficientStock
+	}
+
+	// Postgres is now append-only — no transaction or FOR UPDATE needed.
+	var reservationId int64
+	if err := r.db.QueryRow(`SELECT nextval('reservation_id_seq')`).Scan(&reservationId); err != nil {
+		r.rdb.IncrBy(ctx, key, int64(quantity))
+		return nil, fmt.Errorf("next reservation id: %w", err)
+	}
+
+	_, err = r.db.Exec(`
+		INSERT INTO stock_events (reservation_id, item_id, event_type, quantity)
+		VALUES ($1, $2, 'reserved', $3)
+	`, reservationId, reservationItem.Id, quantity)
+	if err != nil {
+		r.rdb.IncrBy(ctx, key, int64(quantity))
+		return nil, fmt.Errorf("insert reserved event: %w", err)
+	}
+
+	return &item.Reservation{
+		Id:       int32(reservationId),
+		TotalFee: float64(quantity) * reservationItem.Price,
+		Quantity: quantity,
+		ItemId:   reservationItem.Id,
+		Status:   "reserved",
+	}, nil
+}
+
+func (r *ItemRepositoryPostgres) ReleaseReservation(reservationId int32) error {
+	ctx := context.Background()
+
+	var quantity int32
+	var itemId int32
+	err := r.db.QueryRow(`
+		SELECT quantity, item_id FROM stock_events
+		WHERE reservation_id = $1 AND event_type = 'reserved'
+	`, reservationId).Scan(&quantity, &itemId)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return errors.New("reservation not found")
+		}
+		return fmt.Errorf("get reservation: %w", err)
+	}
+
+	// Return stock to Redis before writing the event.
+	key := fmt.Sprintf("stock:item:%d", itemId)
+	r.rdb.IncrBy(ctx, key, int64(quantity))
+
+	_, err = r.db.Exec(`
+		INSERT INTO stock_events (reservation_id, item_id, event_type, quantity)
+		VALUES ($1, $2, 'released', $3)
+	`, reservationId, itemId, quantity)
+	return err
+}
+
+func (r *ItemRepositoryPostgres) CompleteReservation(reservationId int32) error {
+	// Stock was already decremented on reserve and stays consumed — no Redis change.
+	// Write the audit event asynchronously to keep the critical path fast.
+	go func() {
+		var quantity int32
+		var itemId int32
+		err := r.db.QueryRow(`
+			SELECT quantity, item_id FROM stock_events
+			WHERE reservation_id = $1 AND event_type = 'reserved'
+		`, reservationId).Scan(&quantity, &itemId)
+		if err != nil {
+			return
+		}
+		r.db.Exec(`
+			INSERT INTO stock_events (reservation_id, item_id, event_type, quantity)
+			VALUES ($1, $2, 'completed', $3)
+		`, reservationId, itemId, quantity)
+	}()
+	return nil
+}


### PR DESCRIPTION
Closes #24 (partial)

## Problem
`SELECT ... FOR UPDATE` on a single item row creates a global serialization queue: every concurrent reservation must wait for the previous transaction to release the lock. Under load this causes a cascade — goroutines pile up holding DB connections, connections exhaust, and requests fail with `context deadline exceeded`.

## Solution
Replace the row lock with a Redis `DECRBY`:
- **Atomic**: Redis is single-threaded, so DECRBY is naturally race-free
- **O(1)**: no queue, no waiting, sub-millisecond regardless of concurrency
- **Lock-free**: Postgres is now purely append-only for audit events

Reserve path: `Redis DECRBY → check remaining → nextval → INSERT event`  
If DECRBY goes negative, compensate with `INCRBY` and return `ErrInsufficientStock`.

## Other changes
- 10 products seeded (was 1) with 1B initial stock each — distributes load across keys
- Stock service migrated from in-memory to Postgres + Redis
- Dedicated Redis instance per service (redis-order, redis-payment, redis-stock)
- Postgres `max_connections=500` to handle higher parallelism
- Redis idempotency gateway added to stock service

## Test plan
- [ ] Reserve returns 200 under concurrent load without deadline exceeded errors
- [ ] DECRBY correctly prevents overselling (remaining < 0 → reject + compensate)
- [ ] Stock counters seeded correctly on startup (check logs: "Stock counters seeded in Redis")

🤖 Generated with [Claude Code](https://claude.com/claude-code)